### PR TITLE
Fix builds for Travis and AppVeyor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ name = "trianglell"
 path = "examples/trianglell/main.rs"
 
 
-[dev_dependencies]
+[dev-dependencies]
 cgmath = "0.7"
 gfx_gl = "0.3"
 rand = "0.3"
@@ -143,5 +143,5 @@ noise = "0.1"
 image = "0.12.3"
 winit = "0.5"
 
-[target.x86_64-unknown-linux-gnu.dev_dependencies]
+[target.x86_64-unknown-linux-gnu.dev-dependencies]
 glfw = "0.12"


### PR DESCRIPTION
#1 shouldn't be merged into `master`. Thus this new PR.

---

It turns out that `dev_dependencies` was rejected by Travis and AppVeyor. Changing to the standard syntax `dev-dependencies` should fix this.